### PR TITLE
Arreglando Comentario sobre truncate

### DIFF
--- a/11-truncate.sql
+++ b/11-truncate.sql
@@ -4,7 +4,7 @@ USE metro_cdmx;
 
 TRUNCATE TABLE `stations_delete`;
 
--- Esto es para que vean cómo un delete from NO reestablece los id
+-- Esto es para que vean cómo un truncate SI reestablece los id
 INSERT INTO `stations_delete` (name) VALUES
 ("Lázaro Cárdens"), -- Lázaro Cárdenas
 ("Ferería"), -- Ferrería 


### PR DESCRIPTION
En el comentario se especificó el uso del truncate el cual corresponde a este ejemplo.